### PR TITLE
Update old test, add case for draw crash

### DIFF
--- a/test/draw_crash.php
+++ b/test/draw_crash.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once(__DIR__ . '/../tournament.php');
+
+function generateScenario() {
+  $players = [];
+  for ($i = 0; $i < 10; $i++) {
+    $players[] = [
+      'dropped' => false,
+      'playerId' => chr(65 + $i),
+      'opponents' => [],
+      'points' => 0
+    ];
+  }
+  $afterRound1 = playRound($players);
+  print_r($afterRound1);
+  $afterRound2 = playRound($afterRound1);
+}
+
+function playRound($players, $lastRound = false) {
+  echo "=== ROUND ===\n";
+  $pairings = (new Pairings($players))->pair();
+  $nextRoundPLayers = [];
+  foreach ($pairings as $idx => $pairing) {
+    $pairing[0]['opponents'][] = $pairing[1]['playerId'];
+    $pairing[1]['opponents'][] = $pairing[0]['playerId'];
+
+    echo $pairing[0]['playerId'] . " (" . $pairing[0]['points'] . ") is playing " . $pairing[1]['playerId'] . " (" . $pairing[1]['points'] . ")\n";
+
+    if ($idx < 4 && $pairing[0]['playerId'] !== 0) {
+      $pairing[0]['points'] += 3;
+      echo $pairing[0]['playerId'] . " wins\n";
+    } elseif ($idx == 4 && $pairing[0]['playerId'] !== 0 && $pairing[1]['playerId'] !== 0) {
+      $pairing[0]['points'] += 1;
+      $pairing[1]['points'] += 1;
+      echo $pairing[0]['playerId'] . " and " . $pairing[1]['playerId'] . " Draw\n";
+    }
+    if ($pairing[0]['playerId'] !== 0)
+      $nextRoundPlayers[] = $pairing[0];
+    if ($pairing[1]['playerId'] !== 0)
+      $nextRoundPlayers[] = $pairing[1];
+  }
+  return $nextRoundPlayers;
+}
+
+generateScenario();

--- a/test/pairings.php
+++ b/test/pairings.php
@@ -6,7 +6,12 @@ function generateScenario() {
   $num_players = mt_rand(6, 11);
   $players = [];
   for ($i = 0; $i < $num_players; $i++) {
-    $players[] = ['player_id' => chr(65 + $i), 'opponents' => [], 'points' => 0];
+    $players[] = [
+      'dropped' => false,
+      'playerId' => chr(65 + $i),
+      'opponents' => [],
+      'points' => 0
+    ];
   }
   $afterRound1 = playRound($players);
   $afterRound2 = playRound($afterRound1);
@@ -18,38 +23,38 @@ function playRound($players, $lastRound = false) {
   $pairings = (new Pairings($players))->pair();
   $nextRoundPlayers = [];
   foreach ($pairings as $pairing) {
-    $pairing[0]['opponents'][] = $pairing[1]['player_id'];
-    $pairing[1]['opponents'][] = $pairing[0]['player_id'];
+    $pairing[0]['opponents'][] = $pairing[1]['playerId'];
+    $pairing[1]['opponents'][] = $pairing[0]['playerId'];
 
-    echo $pairing[0]['player_id'] . " (" . $pairing[0]['points'] . ") is playing " . $pairing[1]['player_id'] . " (" . $pairing[1]['points'] . ")\n";
+    echo $pairing[0]['playerId'] . " (" . $pairing[0]['points'] . ") is playing " . $pairing[1]['playerId'] . " (" . $pairing[1]['points'] . ")\n";
 
     // Random result of match
     $result = mt_rand(0, 5);
-    if ($result === 0 && $pairing[0]['player_id'] !== 0 && $pairing[1]['player_id'] !== 0) {
+    if ($result === 0 && $pairing[0]['playerId'] !== 0 && $pairing[1]['playerId'] !== 0) {
       $pairing[0]['points'] += 1;
       $pairing[1]['points'] += 1;
-      echo $pairing[0]['player_id'] . " and " . $pairing[1]['player_id'] . " Draw\n";
-    } elseif ($result <= 3 || $pairing[0]['player_id'] !== 0) {
+      echo $pairing[0]['playerId'] . " and " . $pairing[1]['playerId'] . " Draw\n";
+    } elseif ($result <= 3 || $pairing[0]['playerId'] !== 0) {
       $pairing[0]['points'] += 3;
-      echo $pairing[0]['player_id'] . " wins\n";
+      echo $pairing[0]['playerId'] . " wins\n";
     } else {
       $pairing[1]['points'] += 3;
-      echo $pairing[1]['player_id'] . " wins\n";
+      echo $pairing[1]['playerId'] . " wins\n";
     }
     if ($lastRound) {
       // you can't drop after the last round.
       continue;
     }
     // Simulate drops
-    if (mt_rand(0, 5) !== 0 && $pairing[0]['player_id'] !== 0) {
+    if (mt_rand(0, 5) !== 0 && $pairing[0]['playerId'] !== 0) {
       $nextRoundPlayers[] = $pairing[0];
-    } else if ($pairing[0]['player_id'] !== 0) {
-      echo $pairing[0]['player_id'] . " drops\n";
+    } else if ($pairing[0]['playerId'] !== 0) {
+      echo $pairing[0]['playerId'] . " drops\n";
     }
-    if (mt_rand(0, 5) !== 0 && $pairing[1]['player_id'] !== 0) {
+    if (mt_rand(0, 5) !== 0 && $pairing[1]['playerId'] !== 0) {
       $nextRoundPlayers[] = $pairing[1];
-    } else if ($pairing[1]['player_id'] !== 0) {
-      echo $pairing[1]['player_id'] . " drops\n";
+    } else if ($pairing[1]['playerId'] !== 0) {
+      echo $pairing[1]['playerId'] . " drops\n";
     }
   }
   return $nextRoundPlayers;


### PR DESCRIPTION
If you run draw_crash.php, it simulates the case that is causing the infinite loop when trying to pair the second round after a 10 man pod has a single draw.

The pairing logic is black magic to me, but it looks like it gets stuck in the do-while loop of `getPairingOrdering`.
